### PR TITLE
Kotlnizing implementation by allowing the use of DSL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Add the dependency
 </details>
 
 ## Add to your app
-Adding Maildroid to your app is straight forword process. Library is using Builder pattern to achieve flexebilty and easy to read wholesome implementation
+Adding Maildroid to your app is straight forword process. Library is using Builder pattern to achieve flexebilty and easy to read wholesome implementation:
+
 ```kotlin
   MaildroidX.Builder()
             .smtp("")
@@ -118,6 +119,34 @@ Adding Maildroid to your app is straight forword process. Library is using Build
             },3000)
             .mail()
 ```
+
+**DSL implementation:**
+
+```kotlin
+sendEmail {
+      smtp("smtp.mailtrap.io")
+      smtpUsername("username")
+      smtpPassword("password")
+      smtpAuthentication(true)
+      port("2525")
+      type(MaildroidXType.HTML)
+      to("johndoe@email.com")
+      from("janedoen@email.com")
+      subject("Hello!")
+      body("email body")
+      attachment("path_to_file/file.txt")
+      callback {
+          timeOut(3000)
+          onSuccess {
+              Log.d("MaildroidX",  "SUCCESS")
+          }
+          onFail {
+              Log.d("MaildroidX",  "FAIL")
+          }
+      }
+ }
+```
+
 ### Documentation
 ***
 #### Documentation for version v.0.0.1

--- a/app/src/main/java/co/nedim/maildroid/MainActivity.kt
+++ b/app/src/main/java/co/nedim/maildroid/MainActivity.kt
@@ -3,12 +3,12 @@ package co.nedim.maildroid
 import android.app.ProgressDialog
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
-import co.nedim.maildroidx.MaildroidX
-import co.nedim.maildroidx.MaildroidXType
+import co.nedim.maildroidx.*
 import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
@@ -27,11 +27,37 @@ class MainActivity : AppCompatActivity() {
             val to = toMail.text.toString()
             val text = text.text.toString()
 
-            send(to,text)
+            sendDsl(to,text)
 
         })
 
 
+    }
+
+    private fun sendDsl(to:String,text:String) {
+        sendEmail {
+            smtp("smtp.mailtrap.io")
+            smtpUsername("")
+            smtpPassword("")
+            smtpAuthentication(true)
+            port("465")
+            type(MaildroidXType.HTML)
+            to(to)
+            from("someoneover@interenet.com")
+            subject("Hello v1")
+            body(text)
+            callback {
+                timeOut(3000)
+                onSuccess {
+                    Toast.makeText(this@MainActivity,"Mail sent!",Toast.LENGTH_SHORT).show()
+                    Log.d(TAG,  "SUCCESS")
+                }
+                onFail {
+                    Toast.makeText(this@MainActivity,"Error!",Toast.LENGTH_SHORT).show()
+                    Log.d(TAG,  "ERROR")
+                }
+            }
+        }
     }
 
     fun send(to:String,text:String){
@@ -54,7 +80,7 @@ class MainActivity : AppCompatActivity() {
             .body(text)
             .attachment("${this@MainActivity.filesDir.path}/abc.txt")
             .onCompleteCallback(object : MaildroidX.onCompleteCallback{
-
+                override val timeout: Long = 3000
 
                 override fun onSuccess() {
                     Toast.makeText(this@MainActivity,"Mail sent!",Toast.LENGTH_SHORT).show()
@@ -67,9 +93,12 @@ class MainActivity : AppCompatActivity() {
                     Toast.makeText(this@MainActivity,"Error!",Toast.LENGTH_SHORT).show()
                     pd.cancel()
                 }
-            },3000)
+            })
             .mail()
+    }
 
+    companion object {
+        val TAG = MainActivity::class.java.name
     }
 
 }

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
@@ -14,8 +14,6 @@ import javax.mail.internet.MimeMultipart
 import javax.activation.FileDataSource
 import javax.mail.BodyPart
 
-
-
 class MaildroidX(
     val to:String?,
     val from:String?,
@@ -49,11 +47,11 @@ class MaildroidX(
         builder.attachments,
         builder.type,
         builder.successCallback,
-        builder.mailSuccess)
+        builder.mailSuccess
+    )
 
 
-
-    class Builder {
+    open class Builder {
         var to:String? = null
             private set
         var from:String? = null
@@ -103,9 +101,9 @@ class MaildroidX(
         fun attachment(attachments: String) = apply { this.attachments = attachments }
 
         fun type(type: MaildroidXType) = apply { this.type = type.toString() }
-        
 
-        fun onCompleteCallback(successCallback: onCompleteCallback?, timeout:Long) = apply {
+
+        fun onCompleteCallback(successCallback: onCompleteCallback?) = apply {
 
             Handler().postDelayed({
                 if(mailSuccess) {
@@ -113,10 +111,10 @@ class MaildroidX(
                 }else{
                     successCallback?.onFail()
                 }
-            }, timeout)
-            }
+            }, successCallback?.timeout ?: 0)
+        }
 
-            fun mail(): Boolean {
+        fun mail(): Boolean {
 
             val typeHTML:String = "text/html"
             val typePLAIN:String = "text/plain"
@@ -133,7 +131,7 @@ class MaildroidX(
                     throw IllegalArgumentException("MaildroidX detected that you didn't pass [smtp] value in to the builder!")
 
                 if(!smtpAuthentication)
-                   throw IllegalArgumentException("MaildroidX detected that you didn't pass [smtpAuthentication] value to the builder!")
+                    throw IllegalArgumentException("MaildroidX detected that you didn't pass [smtpAuthentication] value to the builder!")
 
                 if(port.isEmpty())
                     throw IllegalArgumentException("MaildroidX detected that you didn't pass [port] value to the builder!")
@@ -147,11 +145,11 @@ class MaildroidX(
                     throw AuthenticationFailedException("MaildroidX detected that you didn't pass [smtpUsername] or [smtpPassword] to the builder!")
 
 
-                    props.put("mail.smtp.host", smtp)
-                    props.put("mail.smtp.socketFactory.port", port)
-                    props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory")
-                    props.put("mail.smtp.auth", smtpAuthentication)
-                    props.put("mail.smtp.port", port)
+                props.put("mail.smtp.host", smtp)
+                props.put("mail.smtp.socketFactory.port", port)
+                props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory")
+                props.put("mail.smtp.auth", smtpAuthentication)
+                props.put("mail.smtp.port", port)
 
 
 
@@ -193,11 +191,12 @@ class MaildroidX(
 
                     // Part two is attachment
                     messageBodyPart = MimeBodyPart()
-                    val filename = attachments
-                    val source = FileDataSource(filename)
-                    messageBodyPart.setDataHandler(DataHandler(source))
-                    messageBodyPart.setFileName(filename)
-                    multipart.addBodyPart(messageBodyPart)
+                    attachments?.let { filename ->
+                        val source = FileDataSource(filename)
+                        messageBodyPart.setDataHandler(DataHandler(source))
+                        messageBodyPart.setFileName(filename)
+                        multipart.addBodyPart(messageBodyPart)
+                    }
 
                     // Send the complete message parts
                     message.setContent(multipart)
@@ -221,7 +220,7 @@ class MaildroidX(
                     Log.i("IOException","IOException " + e.printStackTrace())
                 }
             }
-                return false
+            return false
         }
 
 
@@ -234,6 +233,39 @@ class MaildroidX(
     interface onCompleteCallback {
         fun onSuccess()
         fun onFail()
+        val timeout: Long
+
+        open class Builder(
+            private var onSuccess: (() -> Unit)? = null,
+            private var onFail: (() -> Unit)? = null,
+            private var timeout: Long = 3000
+        ) {
+
+            fun timeOut(timeout: Long) = apply {
+                this.timeout = timeout
+            }
+
+            fun onSuccess(onSuccess: () -> Unit) = apply {
+                this.onSuccess = onSuccess
+            }
+
+            fun onFail(onFail: () -> Unit) = apply {
+                this.onFail = onFail
+            }
+
+            fun build(): onCompleteCallback = object : onCompleteCallback {
+                override val timeout: Long = this@Builder.timeout
+
+                override fun onSuccess() {
+                    this@Builder.onSuccess?.invoke()
+                }
+
+                override fun onFail() {
+                    this@Builder.onFail?.invoke()
+                }
+
+            }
+        }
     }
 
 

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXDsl.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXDsl.kt
@@ -1,0 +1,73 @@
+package co.nedim.maildroidx
+
+@DslMarker
+annotation class EmailDsl
+
+@EmailDsl
+class MaildroidXBuilderDsl: MaildroidX.Builder()
+
+@EmailDsl
+class CallbackBuilderDsl: MaildroidX.onCompleteCallback.Builder()
+
+/**
+ * Builds and sends email.
+ * <p>Simple dsl definition to provide an easier way of sending email without having
+ * to directly instantiate [MaildroidX.Builder()] or call [MaildroidX.Builder().mail()].</p>
+ *
+ * <pre>
+ *     sendEmail {
+ *          smtp("smtp.mailtrap.io")
+ *          smtpUsername("username")
+ *          smtpPassword("password")
+ *          smtpAuthentication(true)
+ *          port("2525")
+ *          type(MaildroidXType.HTML)
+ *          to("johndoe@email.com")
+ *          from("janedoen@email.com")
+ *          subject("Hello!")
+ *          body("email body")
+ *          attachment("path_to_file/file.txt")
+ *          callback {
+ *              timeOut(3000)
+ *              onSuccess {
+ *                  Log.d("MaildroidX",  "SUCCESS")
+ *              }
+ *              onFail {
+ *                  Log.d("MaildroidX",  "FAIL")
+ *              }
+ *          }
+ *     }
+ * </pre>
+ *
+ * @param buildMaildroidX lambda expression scoped as [MaildroidX.Builder]
+ */
+inline fun sendEmail(buildMaildroidX: MaildroidXBuilderDsl.() -> Unit) {
+    val maildroidXBuilder = MaildroidXBuilderDsl()
+    maildroidXBuilder.buildMaildroidX()
+    maildroidXBuilder.mail()
+}
+
+
+/**
+ * Builds the callbacks for the email response.
+ *
+ * <pre>
+ *     callback {
+ *          timeout(3000)
+ *          onSuccess {
+ *              Log.d("MaildroidX",  "SUCCESS")
+ *          }
+ *          onFail {
+ *              Log.d("MaildroidX",  "FAIL")
+ *          }
+ *      }
+ * </pre>
+ *
+ * @param buildCallBack lambda expression scoped as [CallbackBuilderDsl]
+ */
+inline fun MaildroidX.Builder.callback(buildCallBack: CallbackBuilderDsl.() -> Unit) {
+    val callbackBuilder = CallbackBuilderDsl()
+    callbackBuilder.buildCallBack()
+    val callBack = callbackBuilder.build()
+    this.onCompleteCallback(callBack)
+}


### PR DESCRIPTION
# Description

Implementation of a couple of functions to allow to have a more kotlinized approach to using this library through a simple DSL definition.

Updated the **README.md** to reflect this new way of sending an email.

# Code Sample
```kotlin
sendEmail {
      smtp("smtp.mailtrap.io")
      smtpUsername("username")
      smtpPassword("password")
      smtpAuthentication(true)
      port("2525")
      type(MaildroidXType.HTML)
      to("johndoe@email.com")
      from("janedoen@email.com")
      subject("Hello!")
      body("email body")
      attachment("path_to_file/file.txt")
      callback {
          timeOut(3000)
          onSuccess {
              Log.d("MaildroidX",  "SUCCESS")
          }
          onFail {
              Log.d("MaildroidX",  "FAIL")
          }
      }
 }
```