### PR TITLE
Solve the problem of garbled code, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add dependency
 ```gradle
 
 dependencies {
-	        implementation 'com.github.nedimf:maildroid:v0.0.2'
+	        implementation 'com.github.nedimf:maildroid:v0.0.3'
           }
 ```
 

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
@@ -139,7 +139,7 @@ class MaildroidX(
         fun send(): Boolean {
 
 
-            val typeHTML:String = "text/html"
+            val typeHTML:String = "text/html; charset=utf-8"
             val typePLAIN:String = "text/plain"
 
             if(type.equals("HTML"))


### PR DESCRIPTION
- I find other language characters in mail's body showed garbled. So I change the encoding from ascii as default to utf-8. It looks work well for this problem.
- The code in readme doesn't work in v0.0.2, it looks like should change to v0.0.3.