### PR TITLE
Allow multiple CC / BCC, Kotlin refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+*.xml

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
@@ -44,6 +44,9 @@ class MaildroidX(
     val successCallback: onCompleteCallback?,
     val mailSuccess: Boolean?
 ) {
+    companion object {
+        const val TAG = "MaildroidX"
+    }
 
     private constructor(builder: Builder) : this(
         builder.toRecipients,
@@ -228,8 +231,8 @@ class MaildroidX(
                 if (isJavascriptDisabled) {
 
                     Log.e(
-                        "isJavascriptDisabled",
-                        "This setting to true can cause distortion problem with CSS in E-mail layout. It should be only used when CSS is not required. "
+                        TAG,
+                        "isJavascriptDisabled is set to true : this setting to true can cause distortion problem with CSS in E-mail layout. It should be only used when CSS is not required. "
                     )
                     body = body?.let { strapOfUnwantedJS(it) }
 
@@ -243,12 +246,12 @@ class MaildroidX(
 
                 if (isStartTLSEnabled) {
                     Log.i(
-                        "isStartTLSEnabled",
-                        "Your SMTP server has to support STARTTLS, to use this option"
+                        TAG,
+                        "STARTTLS is enabled. Your SMTP server has to support STARTTLS to use this option"
                     )
                     props["mail.smtp.starttls.enable"] = true
                 } else {
-                    Log.i("isStartTLSEnabled", "MaildroidX: STARTTLS is disabled")
+                    Log.i(TAG, "STARTTLS is disabled")
                     props["mail.smtp.starttls.enable"] = false
                 }
 
@@ -367,7 +370,7 @@ class MaildroidX(
 
                     mailSuccess = true
 
-                    Log.i("Success", "Success, mail sent [STATUS: $mailSuccess]")
+                    Log.i(TAG, "Success, mail sent [STATUS: $mailSuccess]")
 
                     /**
                      *
@@ -384,28 +387,28 @@ class MaildroidX(
                      */
 
                 } catch (e: MessagingException) {
-                    Log.e("MessagingException", e.toString())
+                    Log.e(TAG, "MessagingException : ${e.message}")
                     errorMessage = e.toString()
                 } catch (e: SMTPAddressSucceededException) {
-                    Log.e("SMTPAddressSEx", e.toString())
+                    Log.e(TAG, "SMTPAddressSucceededException : ${e.message}")
                     errorMessage = e.toString()
 
                 } catch (e: SMTPAddressFailedException) {
-                    Log.e("SMTPAddressFEx", e.toString())
+                    Log.e(TAG, "SMTPAddressFailedException : ${e.message}")
                     errorMessage = e.toString()
 
 
                 } catch (e: SMTPSendFailedException) {
-                    Log.e("SMTPSendFEx", e.toString())
+                    Log.e(TAG, "SMTPSendFailedException : ${e.message}")
                     errorMessage = e.toString()
 
 
                 } catch (e: SMTPSenderFailedException) {
-                    Log.e("SMTPSenderFEx", e.toString())
+                    Log.e(TAG, "SMTPSenderFailedException : ${e.message}")
                     errorMessage = e.toString()
 
                 } catch (e: IOException) {
-                    Log.e("IOException", "IOException " + e.printStackTrace())
+                    Log.e(TAG, "IOException : ${e.message}")
                     errorMessage = e.toString()
 
                 } finally {

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidX.kt
@@ -25,9 +25,7 @@ import java.io.IOException
 
 class MaildroidX(
     val toRecipients: List<String>?,
-    val cc: String?,
     val ccRecipients: List<String>?,
-    val bcc: String?,
     val bccRecipients: List<String>?,
     val from: String?,
     val subject: String?,
@@ -50,9 +48,7 @@ class MaildroidX(
 
     private constructor(builder: Builder) : this(
         builder.toRecipients,
-        builder.cc,
         builder.ccRecipients,
-        builder.bcc,
         builder.bccRecipients,
         builder.from,
         builder.subject,
@@ -74,13 +70,9 @@ class MaildroidX(
     open class Builder {
         var toRecipients: MutableList<String>? = null
             private set
-        var cc: String? = null
+        var ccRecipients: MutableList<String>? = null
             private set
-        var ccRecipients: List<String>? = null
-            private set
-        var bcc: String? = null
-            private set
-        var bccRecipients: List<String>? = null
+        var bccRecipients: MutableList<String>? = null
             private set
         var from: String? = null
             private set
@@ -122,13 +114,13 @@ class MaildroidX(
             }
         }
 
-        fun cc(cc: String) = apply { this.cc = cc }
+        fun cc(cc: String) = apply { this.ccRecipients?.add(cc) ?: run { this.ccRecipients = mutableListOf(cc)}}
 
-        fun cc(cc: List<String>) = apply { this.ccRecipients = cc }
+        fun cc(cc: List<String>) = apply { this.ccRecipients?.addAll(cc) ?: run { this.ccRecipients = cc.toMutableList() }}
 
-        fun bcc(bcc: String) = apply { this.bcc = bcc }
+        fun bcc(bcc: String) = apply { this.bccRecipients?.add(bcc) ?: run { this.bccRecipients = mutableListOf(bcc)}}
 
-        fun bcc(bcc: List<String>) = apply { this.bccRecipients = bcc }
+        fun bcc(bcc: List<String>) = apply { this.bccRecipients?.addAll(bcc) ?: run { this.bccRecipients = bcc.toMutableList() }}
 
         fun from(from: String) = apply { this.from = from }
 
@@ -165,7 +157,7 @@ class MaildroidX(
         }
 
         fun attachments(attachments: List<MaildroidXAttachment>) {
-            this.attachments = attachments.toMutableList()
+            this.attachments?.addAll(attachments) ?: run { this.attachments = attachments.toMutableList() }
         }
 
         fun type(type: MaildroidXType) = apply { this.type = type.toString() }
@@ -283,48 +275,18 @@ class MaildroidX(
                         )
                     }
 
-                    /**
-                     * Checking if there is any cc recipients in cc constructor.
-                     * If there is cc recipients in ccRecipients, add them to the message
-                     * If there is no cc recipients processed with single cc recipient if it's not null
-                     */
-                    if (ccRecipients != null && ccRecipients!!.isNotEmpty() && ccRecipients!!.size > 1) {
-                        for (email in ccRecipients!!) {
-                            message.addRecipients(
-                                Message.RecipientType.CC,
-                                InternetAddress.parse(email.trim())
-                            )
-                        }
-                    } else {
-                        // Set CC: header field of the header.
-                        cc?.let { email ->
-                            message.addRecipients(
-                                Message.RecipientType.CC,
-                                InternetAddress.parse(email.trim())
-                            )
-                        }
+                    ccRecipients?.forEach { email ->
+                        message.addRecipients(
+                            Message.RecipientType.CC,
+                            InternetAddress.parse(email.trim())
+                        )
                     }
 
-                    /**
-                     * Checking if there is any bcc recipients in bcc constructor.
-                     * If there is bcc recipients in bccRecipients, add them to the message
-                     * If there is no bcc recipients processed with single bcc recipient if it's not null
-                     */
-                    if (bccRecipients != null && bccRecipients!!.isNotEmpty() && bccRecipients!!.size > 1) {
-                        for (email in bccRecipients!!) {
-                            message.addRecipients(
-                                Message.RecipientType.BCC,
-                                InternetAddress.parse(email.trim())
-                            )
-                        }
-                    } else {
-                        // Set BCC: header field of the header.
-                        bcc?.let { email ->
-                            message.addRecipients(
-                                Message.RecipientType.BCC,
-                                InternetAddress.parse(email.trim())
-                            )
-                        }
+                    bccRecipients?.forEach { email ->
+                        message.addRecipients(
+                            Message.RecipientType.BCC,
+                            InternetAddress.parse(email.trim())
+                        )
                     }
 
                     // Set Subject: header field
@@ -353,8 +315,8 @@ class MaildroidX(
                         it.forEach { attachment ->
                             val attachmentPart = MimeBodyPart()
                             attachmentPart.attachFile(attachment.uri)
-                            attachment.filename?.let {
-                                attachmentPart.fileName = it
+                            attachment.filename?.let { filename ->
+                                attachmentPart.fileName = filename
                             }
                             multipart.addBodyPart(attachmentPart)
                         }

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXAttachment.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXAttachment.kt
@@ -1,0 +1,6 @@
+package co.nedim.maildroidx
+
+data class MaildroidXAttachment(
+    val uri : String,
+    val filename : String?
+    )

--- a/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXType.kt
+++ b/maildroidx/src/main/java/co/nedim/maildroidx/MaildroidXType.kt
@@ -1,7 +1,6 @@
 package co.nedim.maildroidx
 
 enum class MaildroidXType(val type: String) {
-
     HTML("text/html"),
     PLAIN("text/plain")
 }


### PR DESCRIPTION
Hey,
 
We started to use maildroid for the mailing part of our company app and I needed to make some changes. 
This should not break anything when migrating from previous versions. 

- Merged the recipient and recipients var into one single list, to be able to add one or more recipients with the same method call
- Did the same for cc, bcc fields
- Reworked the attachment system to allow renaming (filename is optional)
- Unified the log tag (you can of course ignore this if you needed specific tags)

+ Simplified some parts and avoided !! operators .. 

Feel free to ask for changes if anything looks wrong to you. I can also comment unclear parts if needed.

All the best, 
Narval